### PR TITLE
Update useTouches to be server-side rendering safe

### DIFF
--- a/src/useTouches.js
+++ b/src/useTouches.js
@@ -1,5 +1,5 @@
 
-var _touches = "ontouchstart" in window;
+var _touches = typeof window !== "undefined" && "ontouchstart" in window;
 
 module.exports = function () {
   return _touches;


### PR DESCRIPTION
`window` is undefined in node environments. To support server side rendering, a simple typeof short circuit stops it from erroring out.