### PR TITLE
replace string ref with callback function

### DIFF
--- a/src/MultiSlider.js
+++ b/src/MultiSlider.js
@@ -40,7 +40,7 @@ export default class MultiSlider extends React.Component {
   };
 
   xForEvent(e) {
-    var node = this.refs.root;
+    var node = this.root;
     var clientX = e.clientX;
     var m = node.getScreenCTM();
     var p = node.createSVGPoint();
@@ -240,7 +240,7 @@ export default class MultiSlider extends React.Component {
     }
     return (
       <svg
-        ref="root"
+        ref={(node) => { this.root = node; }}
         {...events}
         width="100%"
         height="100%"


### PR DESCRIPTION
I encountered this error using this package: https://reactjs.org/warnings/refs-must-have-owner.html

And discovered that string refs are considered legacy: https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs

And applied the suggested fix: https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element.

And now I no longer encounter the error.  